### PR TITLE
implemented smooth logic for abs and added some lasso tests. All of t…

### DIFF
--- a/cvxpy/atoms/elementwise/smooth_approximations.py
+++ b/cvxpy/atoms/elementwise/smooth_approximations.py
@@ -1,0 +1,110 @@
+"""
+Copyright 2025 CVXPY Developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import List, Tuple
+
+import numpy as np
+
+from cvxpy.atoms.elementwise.elementwise import Elementwise
+from cvxpy.constraints.constraint import Constraint
+from cvxpy.expressions.variable import Variable
+
+
+class smooth_abs(Elementwise):
+    """Elementwise :math:`(1/a) * log (exp(ax) + exp(-ax))`.
+    """
+
+    def __init__(self, x) -> None:
+        super(smooth_abs, self).__init__(x)
+        self.a = 5.0
+
+    def numeric(self, values):
+        x = values[0]
+        results = np.logaddexp(self.a*x, -self.a*x) / self.a
+        # Return -inf outside the domain
+        if np.isscalar(results):
+            if np.isnan(results):
+                return -np.inf
+        else:
+            results[np.isnan(results)] = -np.inf
+        return results
+
+    def sign_from_args(self) -> Tuple[bool, bool]:
+        """Returns sign (is positive, is negative) of the expression.
+        """
+        # Always positive.
+        return (True, False)
+
+    def is_atom_convex(self) -> bool:
+        """Is the atom convex?
+        """
+        return True
+
+    def is_atom_concave(self) -> bool:
+        """Is the atom concave?
+        """
+        return False
+
+    def is_incr(self, idx) -> bool:
+        """Is the composition non-decreasing in argument idx?
+        """
+        print("CRASHING HERE")
+        raise NotImplementedError()
+        return self.args[idx].is_nonneg()
+
+    def is_decr(self, idx) -> bool:
+        """Is the composition non-increasing in argument idx?
+        """
+        print("CRASHING HERE")
+        raise NotImplementedError()
+        return self.args[idx].is_nonpos()
+
+    def _grad(self, values):
+        """Gives the (sub/super)gradient of the atom w.r.t. each argument.
+
+        Matrix expressions are vectorized, so the gradient is a matrix.
+
+        Args:
+            values: A list of numeric values for the arguments.
+
+        Returns:
+            A list of SciPy CSC sparse matrices or None.
+        """
+        rows = self.args[0].size
+        cols = self.size
+        grad_vals = np.tanh(self.a * values[0])
+        return [smooth_abs.elemwise_grad_to_diag(grad_vals, rows, cols)]
+
+    def _verify_hess_vec_args(self):
+        return isinstance(self.args[0], Variable)
+
+    def _hess_vec(self, vec):
+        """ See the docstring of the hess_vec method of the atom class. """
+        x = self.args[0]
+        t = np.tanh(self.a * x.value)
+        hess_vals = self.a * (1 - t**2)
+        return {(x, x): np.diag(vec * hess_vals)}
+
+    def _domain(self) -> List[Constraint]:
+        """Returns constraints describing the domain of the node.
+        """
+        print("CRASHING HERE")
+        raise NotImplementedError()
+        return [self.args[0] >= 0]
+    
+    def point_in_domain(self):
+        print("CRASHING HERE")
+        raise NotImplementedError()
+        return np.zeros(self.shape)

--- a/cvxpy/atoms/elementwise/smooth_approximations.py
+++ b/cvxpy/atoms/elementwise/smooth_approximations.py
@@ -60,16 +60,14 @@ class smooth_abs(Elementwise):
     def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?
         """
-        print("CRASHING HERE")
         raise NotImplementedError()
-        return self.args[idx].is_nonneg()
+        
 
     def is_decr(self, idx) -> bool:
         """Is the composition non-increasing in argument idx?
         """
-        print("CRASHING HERE")
         raise NotImplementedError()
-        return self.args[idx].is_nonpos()
+        
 
     def _grad(self, values):
         """Gives the (sub/super)gradient of the atom w.r.t. each argument.
@@ -100,11 +98,7 @@ class smooth_abs(Elementwise):
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.
         """
-        print("CRASHING HERE")
         raise NotImplementedError()
-        return [self.args[0] >= 0]
     
     def point_in_domain(self):
-        print("CRASHING HERE")
         raise NotImplementedError()
-        return np.zeros(self.shape)

--- a/cvxpy/reductions/expr2smooth/canonicalizers/__init__.py
+++ b/cvxpy/reductions/expr2smooth/canonicalizers/__init__.py
@@ -28,7 +28,9 @@ from cvxpy.reductions.expr2smooth.canonicalizers.div_canon import div_canon
 from cvxpy.reductions.expr2smooth.canonicalizers.log_canon import log_canon
 from cvxpy.reductions.expr2smooth.canonicalizers.exp_canon import exp_canon
 from cvxpy.reductions.expr2smooth.canonicalizers.minimum_canon import minimum_canon
-from cvxpy.reductions.expr2smooth.canonicalizers.abs_canon import smooth_abs_canon, approx_abs_canon
+from cvxpy.reductions.expr2smooth.canonicalizers.abs_canon import abs_canon, smooth_approx_abs_canon
+# when dual LS initialization works correctly we should try to use this smooth_approx_abs logic
+#from cvxpy.reductions.expr2smooth.canonicalizers.smooth_approximations_canon import smooth_approx_abs_canon
 from cvxpy.reductions.expr2smooth.canonicalizers.multiply_canon import multiply_canon
 from cvxpy.reductions.expr2smooth.canonicalizers.pnorm_canon import pnorm_canon
 from cvxpy.reductions.expr2smooth.canonicalizers.power_canon import power_canon
@@ -53,13 +55,13 @@ SMITH_CANON_METHODS = {
 }
 
 SMOOTH_APPROX_METHODS = {
-    abs: approx_abs_canon,
+    abs: smooth_approx_abs_canon,
     maximum : maximum_canon,
     minimum: minimum_canon,
 }
 
 SMOOTH_CANON_METHODS = {
-    abs: smooth_abs_canon,
+    abs: abs_canon,
     maximum : maximum_canon,
     minimum: minimum_canon,
 }

--- a/cvxpy/reductions/expr2smooth/canonicalizers/abs_canon.py
+++ b/cvxpy/reductions/expr2smooth/canonicalizers/abs_canon.py
@@ -20,6 +20,8 @@ from cvxpy.atoms.affine.binary_operators import multiply
 from cvxpy.atoms.elementwise.exp import exp
 from cvxpy.atoms.elementwise.log import log
 from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.expr2smooth.canonicalizers.exp_canon import exp_canon
+from cvxpy.reductions.expr2smooth.canonicalizers.log_canon import log_canon
 
 #def abs_canon(expr, args):
 #    shape = expr.shape
@@ -33,7 +35,7 @@ from cvxpy.expressions.variable import Variable
 #    t2, constr_sq = power_canon(square_expr, square_expr.args)
 #    return t1, [t1**2 == t2] + constr_sq
 
-def smooth_abs_canon(expr, args):
+def abs_canon(expr, args):
     shape = expr.shape
     t1 = Variable(shape, bounds = [0, None])
     y = Variable(shape, bounds = [-1.01, 1.01])
@@ -43,14 +45,20 @@ def smooth_abs_canon(expr, args):
     
     return t1, [y ** 2 == np.ones(shape), t1 == multiply(y, args[0])]
 
-def approx_abs_canon(expr, args):
+def smooth_approx_abs_canon(expr, args):
     # smooth approximation of abs via
     # \frac{1}{a}\cdot\log\left(e^{ax}+e^{-ax}\right)
     shape = expr.shape
     t1 = Variable(shape, bounds = [0, None])
-    a = 1.0
+    a = 5.0
     if args[0].value is not None:
         t1.value = np.abs(args[0].value)
     
-    expr = (1/a) * log(exp(a*args[0]) + exp(-a*args[0]))
-    return t1, [t1 == expr]
+    _exp_pos = exp(multiply(a, args[0]))
+    _exp_neg = exp(multiply(-a, args[0]))
+    exp_pos, constr_pos = exp_canon(_exp_pos, _exp_pos.args)
+    exp_neg, constr_neg = exp_canon(_exp_neg, _exp_neg.args)
+    _log_expr = log(exp_pos + exp_neg)
+    log_expr, constr_log = log_canon(_log_expr, _log_expr.args)
+
+    return t1, [a * t1 == log_expr] + constr_pos + constr_neg + constr_log

--- a/cvxpy/reductions/expr2smooth/canonicalizers/smooth_approximations_canon.py
+++ b/cvxpy/reductions/expr2smooth/canonicalizers/smooth_approximations_canon.py
@@ -1,0 +1,30 @@
+"""
+Copyright 2025 CVXPY developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from cvxpy.atoms.elementwise.smooth_approximations import smooth_abs
+from cvxpy.expressions.variable import Variable
+
+
+def smooth_approx_abs_canon(expr, args):
+    if isinstance(args[0], Variable):
+        return smooth_abs(args[0]), []
+        #return expr, []
+    else:
+        raise NotImplementedError()
+        t = Variable(args[0].shape)
+        if args[0].value is not None:
+            t.value = args[0].value
+        return expr.copy([t]), [t == args[0]]


### PR DESCRIPTION
Implemented smooth logic for abs and added some lasso tests. Tests that used to fail
now work with this new approach.

Right now we canonicalize the smooth approximation using log_canon and exp_canon. As we talked about yesterday @Transurgeon, perhaps the right approach is to instead create an atom for the smoothened version. I did this, and it seems to work too, but for a few (very few) problem instances, IPOPT crashes for the smoothened problem with this approach. However, the issue seems to be related to the dual initialization. If I implement the dual initialization manually and use that, this approach works too. I therefore think we should revisit this once we have figured out the initialization properly. (I created an issue about this a few days ago: https://github.com/coin-or/Ipopt/issues/847)