### PR TITLE
Sparse hess other approach

### DIFF
--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -450,7 +450,8 @@ class multiply(MulExpression):
             x_var = x.args[0] # here x is a Promote because of how we canonicalize
             zeros_x = np.zeros(x_var.size, dtype=int)
             cols = np.arange(y.size)
-            return {(x_var, y): (zeros_x, cols, vec), (y, x_var): (cols, zeros_x, vec)}
+            return {(x_var, y): (zeros_x, cols, vec),
+                    (y, x_var): (cols, zeros_x, vec)}
         
         # x * y with x a vector variable, y a scalar
         if not isinstance(y, Variable) and y.is_affine():
@@ -458,7 +459,8 @@ class multiply(MulExpression):
             y_var = y.args[0] # here y is a Promote because of how we canonicalize
             zeros_y = np.zeros(y_var.size, dtype=int)
             cols = np.arange(x.size)
-            return {(x, y_var): (cols, zeros_y, vec), (y_var, x): (zeros_y, cols, vec)}
+            return {(x, y_var): (cols, zeros_y, vec),
+                    (y_var, x): (zeros_y, cols, vec)}
         
         # if we arrive here both arguments are variables of the same size
         rows = np.arange(x.size)

--- a/cvxpy/atoms/affine/binary_operators.py
+++ b/cvxpy/atoms/affine/binary_operators.py
@@ -263,6 +263,9 @@ class MulExpression(BinaryOperator):
     def _hess_vec(self, vec):
         x = self.args[0]
         y = self.args[1]
+
+        print("THIS SHOULD NEVER RUN!!!!!! Haven't implemented this \n \n \n \n")
+        assert(False)
         
         # constant * atom
         if x.is_constant(): 
@@ -445,16 +448,22 @@ class multiply(MulExpression):
         if not isinstance(x, Variable) and x.is_affine():
             assert(type(x) == Promote)
             x_var = x.args[0] # here x is a Promote because of how we canonicalize
-            return {(x_var, y): vec, (y, x_var): vec}
+            zeros_x = np.zeros(x_var.size, dtype=int)
+            cols = np.arange(y.size)
+            return {(x_var, y): (zeros_x, cols, vec), (y, x_var): (cols, zeros_x, vec)}
         
         # x * y with x a vector variable, y a scalar
         if not isinstance(y, Variable) and y.is_affine():
             assert(type(y) == Promote)
             y_var = y.args[0] # here y is a Promote because of how we canonicalize
-            return {(x, y_var): vec, (y_var, x): vec}
+            zeros_y = np.zeros(y_var.size, dtype=int)
+            cols = np.arange(x.size)
+            return {(x, y_var): (cols, zeros_y, vec), (y_var, x): (zeros_y, cols, vec)}
         
         # if we arrive here both arguments are variables of the same size
-        return {(x, y): np.diag(vec), (y, x): np.diag(vec)}
+        rows = np.arange(x.size)
+        cols = np.arange(x.size)
+        return {(x, y): (rows, cols, vec), (y, x): (rows, cols, vec)}
 
     def graph_implementation(
         self, arg_objs, shape: Tuple[int, ...], data=None

--- a/cvxpy/atoms/atom.py
+++ b/cvxpy/atoms/atom.py
@@ -509,7 +509,7 @@ class Atom(Expression):
         # for nonlinear atoms we typically require that the arguments are variables 
         # (this is guaranteed in the NLP setting through the canonicalization)
         if not self._verify_hess_vec_args():
-            raise ValueError("Argument error in hess_vec.")
+           raise ValueError("Argument error in hess_vec.")
     
         return self._hess_vec(vec)
 

--- a/cvxpy/atoms/elementwise/entr.py
+++ b/cvxpy/atoms/elementwise/entr.py
@@ -96,6 +96,10 @@ class entr(Elementwise):
     def _hess_vec(self, vec):
         """ See the docstring of the hess_vec method of the atom class. """
         x = self.args[0]
+        rows = np.arange(x.size)
+        cols = np.arange(x.size)
+        vals = -vec / x.value
+        return {(x, x): (rows, cols, vals)}
         return {(x, x): np.diag(-vec / x.value)}
 
     def _domain(self) -> List[Constraint]:

--- a/cvxpy/atoms/elementwise/entr.py
+++ b/cvxpy/atoms/elementwise/entr.py
@@ -96,11 +96,9 @@ class entr(Elementwise):
     def _hess_vec(self, vec):
         """ See the docstring of the hess_vec method of the atom class. """
         x = self.args[0]
-        rows = np.arange(x.size)
-        cols = np.arange(x.size)
+        idxs = np.arange(x.size)
         vals = -vec / x.value
-        return {(x, x): (rows, cols, vals)}
-        return {(x, x): np.diag(-vec / x.value)}
+        return {(x, x): (idxs, idxs, vals)}
 
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/exp.py
+++ b/cvxpy/atoms/elementwise/exp.py
@@ -92,4 +92,8 @@ class exp(Elementwise):
     def _hess_vec(self, vec):
         """ See the docstring of the hess_vec method of the atom class. """
         x = self.args[0]
+        rows = np.arange(x.size)
+        cols = np.arange(x.size)
+        vals = np.exp(x.value) * vec
+        return {(x, x): (rows, cols, vals)}
         return {(x, x): np.diag( np.exp(x.value) * vec)}

--- a/cvxpy/atoms/elementwise/exp.py
+++ b/cvxpy/atoms/elementwise/exp.py
@@ -92,8 +92,6 @@ class exp(Elementwise):
     def _hess_vec(self, vec):
         """ See the docstring of the hess_vec method of the atom class. """
         x = self.args[0]
-        rows = np.arange(x.size)
-        cols = np.arange(x.size)
+        idxs = np.arange(x.size)
         vals = np.exp(x.value) * vec
-        return {(x, x): (rows, cols, vals)}
-        return {(x, x): np.diag( np.exp(x.value) * vec)}
+        return {(x, x): (idxs, idxs, vals)}

--- a/cvxpy/atoms/elementwise/kl_div.py
+++ b/cvxpy/atoms/elementwise/kl_div.py
@@ -121,20 +121,28 @@ class kl_div(Elementwise):
         dxdy_vals = - vec / y.value
 
         if x.size == 1:
-            return {(x, x): np.array(np.sum(dx2_vals)),
-                    (y, y): np.diag(dy2_vals),
-                    (x, y): np.array(dxdy_vals),
-                    (y, x): np.array(dxdy_vals)}
+            rows_y = np.arange(y.size)
+            cols_y = np.arange(y.size)
+            zeros_y = np.zeros(y.size, dtype=int)
+            return {(x, x): (0, 0, np.sum(dx2_vals)),
+                    (y, y): (rows_y, cols_y, dy2_vals),
+                    (x, y): (zeros_y, cols_y, dxdy_vals),
+                    (y, x): (rows_y, zeros_y, dxdy_vals)}
         elif y.size == 1:
-            return {(x, x): np.diag(dx2_vals), 
-                    (y, y): np.array(np.sum(dy2_vals)),
-                    (x, y): np.array(dxdy_vals),
-                    (y, x): np.array(dxdy_vals)}
+            rows_x = np.arange(x.size)
+            cols_x = np.arange(x.size)
+            zeros_x = np.zeros(x.size, dtype=int)
+            return {(x, x): (rows_x, cols_x, dx2_vals), 
+                    (y, y): (0, 0, np.sum(dy2_vals)),
+                    (x, y): (rows_x, zeros_x, dxdy_vals),
+                    (y, x): (zeros_x, cols_x, dxdy_vals)}
         else:
-            return {(x, x): np.diag(dx2_vals), 
-                    (y, y): np.diag(dy2_vals),
-                    (x, y): np.diag(dxdy_vals),
-                    (y, x): np.diag(dxdy_vals)}
+            rows = np.arange(x.size)
+            cols = np.arange(x.size)
+            return {(x, x): (rows, cols, dx2_vals), 
+                    (y, y): (rows, cols, dy2_vals),
+                    (x, y): (rows, cols, dxdy_vals),
+                    (y, x): (rows, cols, dxdy_vals)}
     
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/kl_div.py
+++ b/cvxpy/atoms/elementwise/kl_div.py
@@ -121,28 +121,25 @@ class kl_div(Elementwise):
         dxdy_vals = - vec / y.value
 
         if x.size == 1:
-            rows_y = np.arange(y.size)
-            cols_y = np.arange(y.size)
+            idxs = np.arange(y.size)
             zeros_y = np.zeros(y.size, dtype=int)
             return {(x, x): (0, 0, np.sum(dx2_vals)),
-                    (y, y): (rows_y, cols_y, dy2_vals),
-                    (x, y): (zeros_y, cols_y, dxdy_vals),
-                    (y, x): (rows_y, zeros_y, dxdy_vals)}
+                    (y, y): (idxs, idxs, dy2_vals),
+                    (x, y): (zeros_y, idxs, dxdy_vals),
+                    (y, x): (idxs, zeros_y, dxdy_vals)}
         elif y.size == 1:
-            rows_x = np.arange(x.size)
-            cols_x = np.arange(x.size)
+            idxs = np.arange(x.size)
             zeros_x = np.zeros(x.size, dtype=int)
-            return {(x, x): (rows_x, cols_x, dx2_vals), 
+            return {(x, x): (idxs, idxs, dx2_vals), 
                     (y, y): (0, 0, np.sum(dy2_vals)),
-                    (x, y): (rows_x, zeros_x, dxdy_vals),
-                    (y, x): (zeros_x, cols_x, dxdy_vals)}
+                    (x, y): (idxs, zeros_x, dxdy_vals),
+                    (y, x): (zeros_x, idxs, dxdy_vals)}
         else:
-            rows = np.arange(x.size)
-            cols = np.arange(x.size)
-            return {(x, x): (rows, cols, dx2_vals), 
-                    (y, y): (rows, cols, dy2_vals),
-                    (x, y): (rows, cols, dxdy_vals),
-                    (y, x): (rows, cols, dxdy_vals)}
+            idxs = np.arange(x.size)
+            return {(x, x): (idxs, idxs, dx2_vals), 
+                    (y, y): (idxs, idxs, dy2_vals),
+                    (x, y): (idxs, idxs, dxdy_vals),
+                    (y, x): (idxs, idxs, dxdy_vals)}
     
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/log.py
+++ b/cvxpy/atoms/elementwise/log.py
@@ -98,7 +98,11 @@ class log(Elementwise):
     def _hess_vec(self, vec):
         """ See the docstring of the hess_vec method of the atom class. """
         x = self.args[0]
-        return {(x, x): np.diag( -vec / (x.value ** 2))}
+        rows = np.arange(x.size)
+        cols = np.arange(x.size)
+        vals = -vec / (x.value ** 2)
+        return {(x, x): (rows, cols, vals)}
+        #return {(x, x): np.diag( -vec / (x.value ** 2))}
 
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/log.py
+++ b/cvxpy/atoms/elementwise/log.py
@@ -98,11 +98,9 @@ class log(Elementwise):
     def _hess_vec(self, vec):
         """ See the docstring of the hess_vec method of the atom class. """
         x = self.args[0]
-        rows = np.arange(x.size)
-        cols = np.arange(x.size)
+        idxs = np.arange(x.size)
         vals = -vec / (x.value ** 2)
-        return {(x, x): (rows, cols, vals)}
-        #return {(x, x): np.diag( -vec / (x.value ** 2))}
+        return {(x, x): (idxs, idxs, vals)}
 
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -404,12 +404,9 @@ class power(Elementwise):
         x = self.args[0]
         hess_vals = float(p)*float(p-1)*np.power(x.value, float(p)-2)
 
-        rows = np.arange(x.size)
-        cols = np.arange(x.size)
+        idxs = np.arange(x.size)
         vals = hess_vals * vec
-        return {(x, x): (rows, cols, vals)}
-
-        return {(x, x): np.diag(hess_vals * vec)}
+        return {(x, x): (idxs, idxs, vals)}
         
     def _domain(self) -> List[Constraint]:
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/power.py
+++ b/cvxpy/atoms/elementwise/power.py
@@ -403,6 +403,12 @@ class power(Elementwise):
     
         x = self.args[0]
         hess_vals = float(p)*float(p-1)*np.power(x.value, float(p)-2)
+
+        rows = np.arange(x.size)
+        cols = np.arange(x.size)
+        vals = hess_vals * vec
+        return {(x, x): (rows, cols, vals)}
+
         return {(x, x): np.diag(hess_vals * vec)}
         
     def _domain(self) -> List[Constraint]:

--- a/cvxpy/atoms/elementwise/rel_entr.py
+++ b/cvxpy/atoms/elementwise/rel_entr.py
@@ -122,20 +122,28 @@ class rel_entr(Elementwise):
         dxdy_vals = - vec / y.value
 
         if x.size == 1:
-            return {(x, x): np.array(np.sum(dx2_vals)),
-                    (y, y): np.diag(dy2_vals),
-                    (x, y): np.array(dxdy_vals),
-                    (y, x): np.array(dxdy_vals)}
+            rows_y = np.arange(y.size)
+            cols_y = np.arange(y.size)
+            zeros_y = np.zeros(y.size, dtype=int)
+            return {(x, x): (0, 0, np.sum(dx2_vals)),
+                    (y, y): (rows_y, cols_y, dy2_vals),
+                    (x, y): (zeros_y, cols_y, dxdy_vals),
+                    (y, x): (rows_y, zeros_y, dxdy_vals)}
         elif y.size == 1:
-            return {(x, x): np.diag(dx2_vals), 
-                    (y, y): np.array(np.sum(dy2_vals)),
-                    (x, y): np.array(dxdy_vals),
-                    (y, x): np.array(dxdy_vals)}
+            rows_x = np.arange(x.size)
+            cols_x = np.arange(x.size)
+            zeros_x = np.zeros(x.size, dtype=int)
+            return {(x, x): (rows_x, cols_x, dx2_vals), 
+                    (y, y): (0, 0, np.sum(dy2_vals)),
+                    (x, y): (rows_x, zeros_x, dxdy_vals),
+                    (y, x): (zeros_x, cols_x, dxdy_vals)}
         else:
-            return {(x, x): np.diag(dx2_vals), 
-                    (y, y): np.diag(dy2_vals),
-                    (x, y): np.diag(dxdy_vals),
-                    (y, x): np.diag(dxdy_vals)}
+            rows = np.arange(x.size)
+            cols = np.arange(x.size)
+            return {(x, x): (rows, cols, dx2_vals), 
+                    (y, y): (rows, cols, dy2_vals),
+                    (x, y): (rows, cols, dxdy_vals),
+                    (y, x): (rows, cols, dxdy_vals)}
 
     def _domain(self):
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/rel_entr.py
+++ b/cvxpy/atoms/elementwise/rel_entr.py
@@ -122,28 +122,25 @@ class rel_entr(Elementwise):
         dxdy_vals = - vec / y.value
 
         if x.size == 1:
-            rows_y = np.arange(y.size)
-            cols_y = np.arange(y.size)
+            idxs = np.arange(y.size)
             zeros_y = np.zeros(y.size, dtype=int)
             return {(x, x): (0, 0, np.sum(dx2_vals)),
-                    (y, y): (rows_y, cols_y, dy2_vals),
-                    (x, y): (zeros_y, cols_y, dxdy_vals),
-                    (y, x): (rows_y, zeros_y, dxdy_vals)}
+                    (y, y): (idxs, idxs, dy2_vals),
+                    (x, y): (zeros_y, idxs, dxdy_vals),
+                    (y, x): (idxs, zeros_y, dxdy_vals)}
         elif y.size == 1:
-            rows_x = np.arange(x.size)
-            cols_x = np.arange(x.size)
+            idxs = np.arange(x.size)
             zeros_x = np.zeros(x.size, dtype=int)
-            return {(x, x): (rows_x, cols_x, dx2_vals), 
+            return {(x, x): (idxs, idxs, dx2_vals), 
                     (y, y): (0, 0, np.sum(dy2_vals)),
-                    (x, y): (rows_x, zeros_x, dxdy_vals),
-                    (y, x): (zeros_x, cols_x, dxdy_vals)}
+                    (x, y): (idxs, zeros_x, dxdy_vals),
+                    (y, x): (zeros_x, idxs, dxdy_vals)}
         else:
-            rows = np.arange(x.size)
-            cols = np.arange(x.size)
-            return {(x, x): (rows, cols, dx2_vals), 
-                    (y, y): (rows, cols, dy2_vals),
-                    (x, y): (rows, cols, dxdy_vals),
-                    (y, x): (rows, cols, dxdy_vals)}
+            idxs = np.arange(x.size)
+            return {(x, x): (idxs, idxs, dx2_vals), 
+                    (y, y): (idxs, idxs, dy2_vals),
+                    (x, y): (idxs, idxs, dxdy_vals),
+                    (y, x): (idxs, idxs, dxdy_vals)}
 
     def _domain(self):
         """Returns constraints describing the domain of the node.

--- a/cvxpy/atoms/elementwise/trig.py
+++ b/cvxpy/atoms/elementwise/trig.py
@@ -94,6 +94,10 @@ class sin(Elementwise):
         """
         hess_dict = {}
         var = self.args[0]
+        rows = np.arange(var.size)
+        cols = np.arange(var.size)
+        vals = -np.sin(var.value) * vec
+        return {(var, var): (rows, cols, vals)}
         hess_dict[(var, var)] = np.diag(-np.sin(var.value) * vec)
         return hess_dict
 
@@ -169,6 +173,10 @@ class cos(Elementwise):
         """
         hess_dict = {}
         var = self.args[0]
+        rows = np.arange(var.size)
+        cols = np.arange(var.size)
+        vals = -np.cos(var.value) * vec
+        return {(var, var): (rows, cols, vals)}
         hess_dict[(var, var)] = np.diag(-np.cos(var.value) * vec)
         return hess_dict
 

--- a/cvxpy/atoms/elementwise/trig.py
+++ b/cvxpy/atoms/elementwise/trig.py
@@ -92,15 +92,11 @@ class sin(Elementwise):
         Computes the Hessian-vector product dictionary
         for the sin atom. We assume that the argument will be a variable.
         """
-        hess_dict = {}
         var = self.args[0]
-        rows = np.arange(var.size)
-        cols = np.arange(var.size)
+        idxs = np.arange(var.size)
         vals = -np.sin(var.value) * vec
-        return {(var, var): (rows, cols, vals)}
-        hess_dict[(var, var)] = np.diag(-np.sin(var.value) * vec)
-        return hess_dict
-
+        return {(var, var): (idxs, idxs, vals)}
+        
 class cos(Elementwise):
     """Elementwise :math:`\\cos x`.
     """
@@ -171,14 +167,10 @@ class cos(Elementwise):
         Computes the Hessian-vector product dictionary
         for the cos atom. We assume that the argument will be a variable.
         """
-        hess_dict = {}
         var = self.args[0]
-        rows = np.arange(var.size)
-        cols = np.arange(var.size)
+        idxs = np.arange(var.size)
         vals = -np.cos(var.value) * vec
-        return {(var, var): (rows, cols, vals)}
-        hess_dict[(var, var)] = np.diag(-np.cos(var.value) * vec)
-        return hess_dict
+        return {(var, var): (idxs, idxs, vals)}
 
 
 class tan(Elementwise):
@@ -251,7 +243,7 @@ class tan(Elementwise):
         Computes the Hessian-vector product dictionary
         for the tan atom. We assume that the argument will be a variable.
         """
-        hess_dict = {}
         var = self.args[0]
-        hess_dict[(var, var)] = np.diag(2*np.tan(var.value)/np.cos(var.value)**2 * vec)
-        return hess_dict
+        idxs = np.arange(var.size)
+        vals = 2*np.tan(var.value)/np.cos(var.value)**2 * vec
+        return {(var, var): (idxs, idxs, vals)}

--- a/cvxpy/atoms/quad_form.py
+++ b/cvxpy/atoms/quad_form.py
@@ -137,11 +137,11 @@ class QuadForm(Atom):
         canonicalized to w.T @ Q @ w, where w is a single variable
         and Q is a constant matrix.
         """
-        hess_dict = {}
         var = self.args[0]
         Q = self.args[1]
-        hess_dict[(var, var)] = vec * 2 * Q.value
-        return hess_dict
+        Q_coo = sp.coo_matrix(Q.value)
+        
+        return {(var, var): (Q_coo.row, Q_coo.col, 2 * vec * Q_coo.data)}
 
     def shape_from_args(self) -> Tuple[int, ...]:
         return tuple()

--- a/cvxpy/reductions/expr2smooth/canonicalizers/rel_entr_canon.py
+++ b/cvxpy/reductions/expr2smooth/canonicalizers/rel_entr_canon.py
@@ -16,33 +16,45 @@ limitations under the License.
 
 import numpy as np
 
+from cvxpy.atoms.affine.binary_operators import multiply
+from cvxpy.atoms.elementwise.entr import entr
+from cvxpy.atoms.elementwise.log import log
 from cvxpy.expressions.variable import Variable
+from cvxpy.reductions.expr2smooth.canonicalizers.entr_canon import entr_canon
+from cvxpy.reductions.expr2smooth.canonicalizers.log_canon import log_canon
+from cvxpy.reductions.expr2smooth.canonicalizers.multiply_canon import multiply_canon
 
 
-# TODO (DCED): do we want to canonicalize it using log if one of the arguments is constant?
 def rel_entr_canon(expr, args):
-    constraints = []
 
-    if not args[0].is_constant():
-        t1 = Variable(args[0].shape, bounds=[0, None])
-        constraints.append(t1 == args[0])
+    # if the first argument is constant we canonicalize using log
+    if args[0].is_constant():
+        _log = log(args[1])
+        log_expr, constr_log = log_canon(_log, _log.args)
+        x = args[0].value
+        return  x * np.log(x) - multiply(x, log_expr), constr_log
 
-        if args[0].value is not None and np.all(args[0].value >= 1):
-            t1.value = args[0].value
-        else:
-            t1.value = expr.point_in_domain(argument=0)
+    # if the second argument is constant we canonicalize using entropy
+    if args[1].is_constant():
+        _entr = entr(args[0])
+        entr_expr, constr_entr = entr_canon(_entr, _entr.args)
+        _mult = multiply(args[0], np.log(args[1].value))
+        mult_expr, constr_mult = multiply_canon(_mult, _mult.args)
+        return -entr_expr - mult_expr, constr_entr + constr_mult
+
+    # here we know that neither argument is constant
+    t1 = Variable(args[0].shape, bounds=[0, None])
+    t2 = Variable(args[1].shape, bounds=[0, None])
+    constraints = [t1 == args[0], t2 == args[1]]
+
+    if args[0].value is not None and np.min(args[0].value) >= 1:
+        t1.value = args[0].value
     else:
-        t1 = args[0]
+        t1.value = expr.point_in_domain(argument=0)
 
-    if not args[1].is_constant():
-        t2 = Variable(args[1].shape, bounds=[0, None])
-        constraints.append(t2 == args[1])
-
-        if args[1].value is not None and np.all(args[1].value >= 1):
-            t2.value = args[1].value
-        else:
-            t2.value = expr.point_in_domain(argument=1)
+    if args[1].value is not None and np.all(args[1].value >= 1):
+        t2.value = args[1].value
     else:
-        t2 = args[1]
-
+        t2.value = expr.point_in_domain(argument=1)
+    
     return expr.copy([t1, t2]), constraints

--- a/cvxpy/tests/NLP_tests/hess_tests/test_hess_add.py
+++ b/cvxpy/tests/NLP_tests/hess_tests/test_hess_add.py
@@ -13,11 +13,16 @@ class TestHessAdd():
         vec = np.array([-1.0, 2, 4])
         sum = cp.log(x) + cp.exp(x) + 7 * cp.log(x)
         result_dict = sum.hess_vec(vec)
-        result_correct = np.diag([-1 * (-8.0/(1.0**2) + np.exp(1.0)), 
+        correct_matrix = np.diag([-1 * (-8.0/(1.0**2) + np.exp(1.0)), 
                                     2 * (-8.0/(2.0**2) + np.exp(2.0)), 
                                     4 * (-8.0/(3.0**2) + np.exp(3.0))])
-        assert(np.allclose(result_dict[(x, x)], result_correct))
-
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
+       
     def test_three_atoms_different_variables(self):
         n = 3 
         x = cp.Variable((n, ), name='x')
@@ -29,12 +34,30 @@ class TestHessAdd():
         vec = np.array([-1.0, 2, 4])
         sum = cp.log(x) + cp.exp(y) + cp.square(z)
         result_dict = sum.hess_vec(vec)
-        result_correct_xx = np.diag([1 / (1.0**2), -2 / (2.0**2), -4 / (3.0**2)])
-        result_correct_yy = np.diag([-1 * np.exp(4.0), 2 * np.exp(5.0), 4 * np.exp(6.0)])
-        result_correct_zz = np.diag([2 * -1, 2 * 2, 2 * 4])
-        assert(np.allclose(result_dict[(x, x)], result_correct_xx))
-        assert(np.allclose(result_dict[(y, y)], result_correct_yy))
-        assert(np.allclose(result_dict[(z, z)], result_correct_zz))
+        correct_matrix_xx = np.diag([1 / (1.0**2), -2 / (2.0**2), -4 / (3.0**2)])
+        correct_matrix_yy = np.diag([-1 * np.exp(4.0), 2 * np.exp(5.0), 4 * np.exp(6.0)])
+        correct_matrix_zz = np.diag([2 * -1, 2 * 2, 2 * 4])
+
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix_xx))
+
+        computed_hess.fill(0)
+        rows = result_dict[(y, y)][0]
+        cols = result_dict[(y, y)][1]
+        vals = result_dict[(y, y)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix_yy))
+
+        computed_hess.fill(0)
+        rows = result_dict[(z, z)][0]
+        cols = result_dict[(z, z)][1]
+        vals = result_dict[(z, z)][2]       
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix_zz))
         
     def test_negation_one_variable(self):
         n = 3 
@@ -44,4 +67,11 @@ class TestHessAdd():
         neg_log = -cp.log(x)
         result_dict = neg_log.hess_vec(vec)
         correct_matrix = -np.diag([ -5.0/(1.0**2), -4.0/(2.0**2), -3.0/(3.0**2)])
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
+    
+    

--- a/cvxpy/tests/NLP_tests/hess_tests/test_hess_idx.py
+++ b/cvxpy/tests/NLP_tests/hess_tests/test_hess_idx.py
@@ -13,8 +13,13 @@ class TestHessAdd():
         vec = np.array([4])
         log2 = cp.log(x)[2]
         result_dict = log2.hess_vec(vec)
-        result_correct = 4 * (-np.diag(np.array([0, 0, 1/9])))
-        assert(np.allclose(result_dict[(x, x)], result_correct))
+        correct_matrix = 4 * (-np.diag(np.array([0, 0, 1/9])))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_slice_two_idx(self):
         n = 3 
@@ -24,9 +29,14 @@ class TestHessAdd():
         idxs = np.array([1, 2])
         log12 = cp.log(x)[idxs]
         result_dict = log12.hess_vec(vec)
-        result_correct = 2 * (-np.diag(np.array([0, 1/4, 0]))) + \
+        correct_matrix = 2 * (-np.diag(np.array([0, 1/4, 0]))) + \
                          4 * (-np.diag(np.array([0, 0, 1/9]))) 
-        assert(np.allclose(result_dict[(x, x)], result_correct))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     
     def test_slice_two_other_idx(self):
@@ -37,6 +47,11 @@ class TestHessAdd():
         idxs = np.array([0, 2])
         log12 = cp.log(x)[idxs]
         result_dict = log12.hess_vec(vec)
-        result_correct = 2 * (-np.diag(np.array([1 / 2.25, 0, 0]))) + \
+        correct_matrix = 2 * (-np.diag(np.array([1 / 2.25, 0, 0]))) + \
                              4 * (-np.diag(np.array([0, 0, 1/9])))
-        assert(np.allclose(result_dict[(x, x)], result_correct))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))

--- a/cvxpy/tests/NLP_tests/hess_tests/test_hess_multiply.py
+++ b/cvxpy/tests/NLP_tests/hess_tests/test_hess_multiply.py
@@ -46,8 +46,21 @@ class TestHessVecMultiply():
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
         correct_matrix = np.diag(np.array([5.0, 4.0, 3.0]))
-        assert(np.allclose(result_dict[(x, y)], correct_matrix))
-        assert(np.allclose(result_dict[(y, x)], correct_matrix))
+
+        computed_hess_xy = np.zeros((3, 3))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+        assert(np.allclose(computed_hess_xy, correct_matrix))
+
+        computed_hess_yx = np.zeros((3, 3))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+        assert(np.allclose(computed_hess_yx, correct_matrix))
+
         assert(len(result_dict) == 2)
 
     # x * y with x scalar variable, y scalar variable
@@ -60,8 +73,21 @@ class TestHessVecMultiply():
         vec = np.array([5.0])
         result_dict = mult.hess_vec(vec)
         correct_matrix = np.array([[5.0]])
-        assert(np.allclose(result_dict[(x, y)], correct_matrix))
-        assert(np.allclose(result_dict[(y, x)], correct_matrix))
+
+        computed_hess_xy = np.zeros((1, 1))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+        assert(np.allclose(computed_hess_xy, correct_matrix))
+
+        computed_hess_yx = np.zeros((1, 1))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+        assert(np.allclose(computed_hess_yx, correct_matrix))
+
         assert(len(result_dict) == 2)
 
     # x * y with x vector variable, y scalar variable,
@@ -74,8 +100,21 @@ class TestHessVecMultiply():
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
         correct_matrix = np.array([5.0, 4.0, 3.0])
-        assert(np.allclose(result_dict[(x, y)], correct_matrix))
-        assert(np.allclose(result_dict[(y, x)], correct_matrix))
+
+        computed_hess_xy = np.zeros((3, 1))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+        assert(np.allclose(computed_hess_xy.flatten(), correct_matrix))
+
+        computed_hess_yx = np.zeros((1, 3))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+        assert(np.allclose(computed_hess_yx.flatten(), correct_matrix))
+
         assert(len(result_dict) == 2)
 
     # x * y with x scalar variable, y vector variable,
@@ -88,8 +127,21 @@ class TestHessVecMultiply():
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
         correct_matrix = np.array([5.0, 4.0, 3.0])
-        assert(np.allclose(result_dict[(x, y)], correct_matrix))
-        assert(np.allclose(result_dict[(y, x)], correct_matrix))
+
+        computed_hess_xy = np.zeros((1, 3))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+        assert(np.allclose(computed_hess_xy.flatten(), correct_matrix))
+
+        computed_hess_yx = np.zeros((3, 1))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+        assert(np.allclose(computed_hess_yx.flatten(), correct_matrix))
+
         assert(len(result_dict) == 2)
 
     # scalar constant * phi(x) 
@@ -100,8 +152,20 @@ class TestHessVecMultiply():
         mult = cp.multiply(3.0, log)
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
-        correct_matrix = 3 * log.hess_vec(vec)[(x, x)]
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+
+        correct_matrix = np.zeros((3, 3))
+        log_result_dict = log.hess_vec(vec)
+        rows = log_result_dict[(x, x)][0]
+        cols = log_result_dict[(x, x)][1]
+        vals = 3 * log_result_dict[(x, x)][2]
+        correct_matrix[rows, cols] = vals
+
+        computed_hess = np.zeros((3, 3))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
         assert(len(result_dict) == 1)
 
     # phi(x) * scalar constant
@@ -112,8 +176,20 @@ class TestHessVecMultiply():
         mult = cp.multiply(log, 3.0)
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
-        correct_matrix = 3 * log.hess_vec(vec)[(x, x)]
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        
+        correct_matrix = np.zeros((3, 3))
+        log_result_dict = log.hess_vec(vec)
+        rows = log_result_dict[(x, x)][0]
+        cols = log_result_dict[(x, x)][1]
+        vals = 3 * log_result_dict[(x, x)][2]
+        correct_matrix[rows, cols] = vals
+
+        computed_hess = np.zeros((3, 3))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
         assert(len(result_dict) == 1)
 
     # vector constant * phi(x) 
@@ -125,8 +201,20 @@ class TestHessVecMultiply():
         mult = cp.multiply(constant_vector, log)
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
-        correct_matrix = log.hess_vec(vec * constant_vector)[(x, x)]
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+
+        log_result_dict = log.hess_vec(vec * constant_vector)
+        correct_matrix = np.zeros((3, 3))
+        rows = log_result_dict[(x, x)][0]
+        cols = log_result_dict[(x, x)][1]
+        vals = log_result_dict[(x, x)][2]
+        correct_matrix[rows, cols] = vals
+
+        computed_hess = np.zeros((3, 3))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
         assert(len(result_dict) == 1)
 
     # phi(x) * vector constant
@@ -138,7 +226,19 @@ class TestHessVecMultiply():
         mult = cp.multiply(log, constant_vector)
         vec = np.array([5.0, 4.0, 3.0])
         result_dict = mult.hess_vec(vec)
-        correct_matrix = log.hess_vec(vec * constant_vector)[(x, x)]
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        
+        log_result_dict = log.hess_vec(vec * constant_vector)
+        correct_matrix = np.zeros((3, 3))
+        rows = log_result_dict[(x, x)][0]
+        cols = log_result_dict[(x, x)][1]
+        vals = log_result_dict[(x, x)][2]
+        correct_matrix[rows, cols] = vals
+
+        computed_hess = np.zeros((3, 3))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
         assert(len(result_dict) == 1)
 

--- a/cvxpy/tests/NLP_tests/hess_tests/test_hess_rel_entr.py
+++ b/cvxpy/tests/NLP_tests/hess_tests/test_hess_rel_entr.py
@@ -50,9 +50,33 @@ class TestHessVecRelativeEntropy():
         rel_entr = cp.rel_entr(x, y)
         result_dict = rel_entr.hess_vec(vec)
 
+        computed_hess_xx = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess_xx[rows, cols] = vals
+
+        computed_hess_yy = np.zeros((n, n))
+        rows = result_dict[(y, y)][0]
+        cols = result_dict[(y, y)][1]
+        vals = result_dict[(y, y)][2]
+        computed_hess_yy[rows, cols] = vals
+
+        computed_hess_xy = np.zeros((n, n))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+
+        computed_hess_yx = np.zeros((n, n))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+
         H_computed = np.block([
-            [result_dict[(x, x)], result_dict[(x, y)]],
-            [result_dict[(y, x)], result_dict[(y, y)]]
+            [computed_hess_xx, computed_hess_xy],
+            [computed_hess_yx, computed_hess_yy]
         ])
 
         # compute Hessian manually
@@ -78,9 +102,34 @@ class TestHessVecRelativeEntropy():
 
         rel_entr = cp.rel_entr(x, y)
         result_dict = rel_entr.hess_vec(vec)
+
+        computed_hess_xx = np.zeros((1, 1))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess_xx[rows, cols] = vals
+
+        computed_hess_yy = np.zeros((1, 1))
+        rows = result_dict[(y, y)][0]
+        cols = result_dict[(y, y)][1]
+        vals = result_dict[(y, y)][2]
+        computed_hess_yy[rows, cols] = vals
+
+        computed_hess_xy = np.zeros((1, 1))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+
+        computed_hess_yx = np.zeros((1, 1))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+
         H_computed = np.block([
-            [result_dict[(x, x)].reshape(-1, 1), result_dict[(x, y)].reshape(1, -1)],
-            [result_dict[(y, x)].reshape(-1, 1), result_dict[(y, y)].reshape(-1, 1)]
+            [computed_hess_xx, computed_hess_xy],
+            [computed_hess_yx, computed_hess_yy]
         ])
 
         H_analytic = np.array([[vec[0] / x.value[0], - vec[0] / y.value[0]],
@@ -101,9 +150,33 @@ class TestHessVecRelativeEntropy():
         rel_entr = cp.rel_entr(x, y)
         result_dict = rel_entr.hess_vec(vec)
 
+        computed_hess_xx = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess_xx[rows, cols] = vals
+
+        computed_hess_yy = np.zeros((1, 1))
+        rows = result_dict[(y, y)][0]
+        cols = result_dict[(y, y)][1]
+        vals = result_dict[(y, y)][2]
+        computed_hess_yy[rows, cols] = vals
+
+        computed_hess_xy = np.zeros((n, 1))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+
+        computed_hess_yx = np.zeros((1, n))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+
         H_computed = np.block([
-            [result_dict[(x, x)], result_dict[(x, y)].reshape(-1, 1)],
-            [result_dict[(y, x)].reshape(1, -1), result_dict[(y, y)].reshape(-1, 1)]
+            [computed_hess_xx, computed_hess_xy],
+            [computed_hess_yx, computed_hess_yy]
         ])
 
         # compute Hessian manually
@@ -132,9 +205,33 @@ class TestHessVecRelativeEntropy():
         rel_entr = cp.rel_entr(x, y)
         result_dict = rel_entr.hess_vec(vec)
 
+        computed_hess_xx = np.zeros((1, 1))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess_xx[rows, cols] = vals
+
+        computed_hess_yy = np.zeros((n, n))
+        rows = result_dict[(y, y)][0]
+        cols = result_dict[(y, y)][1]
+        vals = result_dict[(y, y)][2]
+        computed_hess_yy[rows, cols] = vals
+
+        computed_hess_xy = np.zeros((1, n))
+        rows = result_dict[(x, y)][0]
+        cols = result_dict[(x, y)][1]
+        vals = result_dict[(x, y)][2]
+        computed_hess_xy[rows, cols] = vals
+
+        computed_hess_yx = np.zeros((n, 1))
+        rows = result_dict[(y, x)][0]
+        cols = result_dict[(y, x)][1]
+        vals = result_dict[(y, x)][2]
+        computed_hess_yx[rows, cols] = vals
+
         H_computed = np.block([
-            [result_dict[(x, x)].reshape(-1, 1), result_dict[(x, y)].reshape(1, -1)],
-            [result_dict[(y, x)].reshape(-1, 1), result_dict[(y, y)]]
+            [computed_hess_xx, computed_hess_xy],
+            [computed_hess_yx, computed_hess_yy]
         ])
 
         # compute Hessian manually

--- a/cvxpy/tests/NLP_tests/hess_tests/test_hess_sum.py
+++ b/cvxpy/tests/NLP_tests/hess_tests/test_hess_sum.py
@@ -13,8 +13,13 @@ class TestHessSum():
         dummy_vec = np.array([3.5])
         sum = cp.sum(cp.log(x))
         result_dict = sum.hess_vec(dummy_vec)
-        result_correct = -3.5 * np.diag(1 / x.value ** 2)
-        assert(np.allclose(result_dict[(x, x)], result_correct))
+        correct_matrix = -3.5 * np.diag(1 / x.value ** 2)
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_sum_two(self):
         n = 3 
@@ -23,8 +28,13 @@ class TestHessSum():
         dummy_vec = np.array([1])
         sum = cp.sum(4 * cp.log(x))
         result_dict = sum.hess_vec(dummy_vec)
-        result_correct = -4 * np.diag(1 / x.value ** 2)
-        assert(np.allclose(result_dict[(x, x)], result_correct))
+        correct_matrix = -4 * np.diag(1 / x.value ** 2)
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
     
     def test_sum_three(self):
         n = 3 
@@ -33,5 +43,10 @@ class TestHessSum():
         dummy_vec = np.array([4]) 
         sum = cp.sum(cp.multiply(np.array([1, 2, 3]), cp.log(x)))
         result_dict = sum.hess_vec(dummy_vec)
-        result_correct = 4 * np.diag(-1 * np.array([1 / (1.0**2), 2 / (2.0**2), 3 / (3.0**2)]))
-        assert(np.allclose(result_dict[(x, x)], result_correct))
+        correct_matrix = 4 * np.diag(-1 * np.array([1 / (1.0**2), 2 / (2.0**2), 3 / (3.0**2)]))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))

--- a/cvxpy/tests/NLP_tests/hess_tests/test_hess_univariate_elementwise_atoms.py
+++ b/cvxpy/tests/NLP_tests/hess_tests/test_hess_univariate_elementwise_atoms.py
@@ -13,7 +13,12 @@ class TestHessVecElementwiseUnivariate():
         log = cp.log(x)
         result_dict = log.hess_vec(vec)
         correct_matrix = np.diag([ -5.0/(1.0**2), -4.0/(2.0**2), -3.0/(3.0**2)])
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_constant_log(self):
         x = np.array([1.0, 2.0, 3.0])
@@ -30,7 +35,12 @@ class TestHessVecElementwiseUnivariate():
         exp = cp.exp(x)
         result_dict = exp.hess_vec(vec)
         correct_matrix = np.diag([ 5.0*np.exp(1.0), 4.0*np.exp(2.0), 3.0*np.exp(3.0)])
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_constant_exp(self):
         x = np.array([1.0, 2.0, 3.0])
@@ -47,7 +57,12 @@ class TestHessVecElementwiseUnivariate():
         entr = cp.entr(x)
         result_dict = entr.hess_vec(vec)
         correct_matrix = np.diag([ -5.0/(1.0), -4.0/(2.0), -3.0/(3.0)])
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_constant_entr(self):
         x = np.array([1.0, 2.0, 3.0])
@@ -64,7 +79,12 @@ class TestHessVecElementwiseUnivariate():
         square = cp.square(x)
         result_dict = square.hess_vec(vec)
         correct_matrix = np.diag([10.0, 8.0, 6.0])
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_constant_square(self):
         x = np.array([1.0, 2.0, 3.0])
@@ -81,7 +101,12 @@ class TestHessVecElementwiseUnivariate():
         power = cp.power(x, 3)
         result_dict = power.hess_vec(vec)
         correct_matrix = np.diag([30.0, 48.0, 54.0])
-        assert(np.allclose(result_dict[(x, x)], correct_matrix))
+        computed_hess = np.zeros((n, n))
+        rows = result_dict[(x, x)][0]
+        cols = result_dict[(x, x)][1]
+        vals = result_dict[(x, x)][2]
+        computed_hess[rows, cols] = vals
+        assert(np.allclose(computed_hess, correct_matrix))
 
     def test_constant_power(self):
         x = np.array([1.0, 2.0, 3.0])

--- a/cvxpy/tests/NLP_tests/test_entropy_related.py
+++ b/cvxpy/tests/NLP_tests/test_entropy_related.py
@@ -21,6 +21,7 @@ class TestStressMLE():
        q_opt_clarabel = q.value
        assert(LA.norm(q_opt_nlp - q_opt_clarabel) <= 1e-4)
 
+
     # nonconvex problem, compute minimum entropy distribution
     # over simplex (the analytical solution is any of the vertices)
     def test_entropy_two(self):
@@ -53,8 +54,57 @@ class TestStressMLE():
         q_opt_clarabel = q.value
         assert(LA.norm(q_opt_nlp - q_opt_clarabel) <= 1e-4)
 
-    # nonnegative matrix factorization with KL objective (nonconvex)
+    def test_rel_entropy_one_switched_arguments(self):
+        np.random.seed(0)
+        n = 40
+        p = np.random.rand(n, )
+        p = p / np.sum(p)
+        q = cp.Variable(n, nonneg=True)
+        A = np.random.rand(n, n)
+        obj = cp.sum(cp.rel_entr(p, A @ q))
+        constraints = [cp.sum(q) == 1]
+        problem = cp.Problem(cp.Minimize(obj), constraints)
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=True)
+        q_opt_nlp = q.value 
+        problem.solve(solver=cp.CLARABEL, verbose=True)
+        q_opt_clarabel = q.value
+        assert(LA.norm(q_opt_nlp - q_opt_clarabel) <= 1e-4)
+
     def test_KL_one(self):
+        np.random.seed(0)
+        n = 40
+        p = np.random.rand(n, )
+        p = p / np.sum(p)
+        q = cp.Variable(n, nonneg=True)
+        A = np.random.rand(n, n)
+        obj = cp.sum(cp.kl_div(A @ q, p))
+        constraints = [cp.sum(q) == 1]
+        problem = cp.Problem(cp.Minimize(obj), constraints)
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=True)
+        q_opt_nlp = q.value 
+        problem.solve(solver=cp.CLARABEL, verbose=True)
+        q_opt_clarabel = q.value
+        assert(LA.norm(q_opt_nlp - q_opt_clarabel) <= 1e-4)
+
+    def test_KL_two(self):
+        np.random.seed(0)
+        n = 40
+        p = np.random.rand(n, )
+        p = p / np.sum(p)
+        q = cp.Variable(n, nonneg=True)
+        A = np.random.rand(n, n)
+        obj = cp.sum(cp.kl_div(p, A @ q))
+        constraints = [cp.sum(q) == 1]
+        problem = cp.Problem(cp.Minimize(obj), constraints)
+        problem.solve(solver=cp.IPOPT, nlp=True, verbose=True)
+        q_opt_nlp = q.value 
+        problem.solve(solver=cp.CLARABEL, verbose=True)
+        q_opt_clarabel = q.value
+        assert(LA.norm(q_opt_nlp - q_opt_clarabel) <= 1e-4)
+
+
+    # nonnegative matrix factorization with KL objective (nonconvex)
+    def test_KL_three(self):
         np.random.seed(0)
         n, m, k = 40, 20, 4
         X_true = np.random.rand(n, k)

--- a/cvxpy/tests/NLP_tests/test_nlp_solvers.py
+++ b/cvxpy/tests/NLP_tests/test_nlp_solvers.py
@@ -142,7 +142,7 @@ class TestExamplesIPOPT():
         constraints = [
             x + y + z == 1,
             x**2 + y**2 - z**2 <= 0,
-            x**2 - y*z <= 0
+            x**2 - cp.multiply(y, z) <= 0
         ]
         problem = cp.Problem(objective, constraints)
         problem.solve(solver=cp.IPOPT, nlp=True)
@@ -296,7 +296,7 @@ class TestNonlinearControl():
             constraints.append(angle_constraint)
         
         problem = cp.Problem(objective, constraints)
-        problem.solve(solver=cp.IPOPT, nlp=True)
+        problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact')
         assert problem.status == cp.OPTIMAL
         assert problem.value == 3.500e+02
 
@@ -320,5 +320,5 @@ class TestCanonicalization():
         objective = cp.Minimize(-cp.sum(cp.log(b - A @ x)))
         problem = cp.Problem(objective, [])
         # Solve the problem
-        problem.solve(solver=cp.IPOPT, nlp=True)
+        problem.solve(solver=cp.IPOPT, nlp=True, hessian_approximation='exact')
         assert problem.status == cp.OPTIMAL


### PR DESCRIPTION
This PR contains another implementation of sparse hessians. It avoids conversion to dense arrays. The sum-logic is done using coo_matrix.sum_duplicates() which made the code inside ipopt_nlpif.py pretty neat and short.

The PR also contains a change in the canonicalization of the relative entropy that I've wanted to do for some time. If one of the arguments is constant, we canonicalize it using the entropy function or the log function instead. This change solves an argument error in hess_vec, because hess_vec for relative entropy assumes that both arguments are variables.

@Transurgeon Let's chat and see if and how we can combine this PR with your current PR. 