### PR TITLE
Fix NaN validation

### DIFF
--- a/cvxpy/expressions/leaf.py
+++ b/cvxpy/expressions/leaf.py
@@ -601,9 +601,14 @@ class Leaf(expression.Expression):
                     attr_str = 'in bounds'
                 else:
                     attr_str = ([k for (k, v) in self.attributes.items() if v] + ['real'])[0]
-                if np.isnan(val).any():
+                if np.isnan(val).any() and self.variables():
                     # necessary for NLP package extension and computing the structural jacobian
+                    # Only allow NaN for Variables, not Parameters
                     return val
+                elif np.isnan(val).any():
+                    raise ValueError(
+                        "%s value must be real." % self.__class__.__name__
+                    )
                 else:
                     raise ValueError(
                        "%s value must be %s." % (self.__class__.__name__, attr_str)


### PR DESCRIPTION
Parameters should raise ValueError when assigned NaN values, but Variables need to allow NaN for NLP structural Jacobian/Hessian computation. The previous code allowed NaN for all Leaf types, breaking upstream test test_nan_in_parameter_raises.

The fix checks self.variables() to distinguish Variables (returns [self]) from Parameters (returns []).
@dance858 will we do something similar for the differentiation engine? What is the plan to provide the sparsity pattern?