### PR TITLE
Propagate initial values to reduced variables for diag attribute

### DIFF
--- a/cvxpy/reductions/cvx_attr2constr.py
+++ b/cvxpy/reductions/cvx_attr2constr.py
@@ -120,7 +120,7 @@ def lower_value(variable, value=None) -> np.ndarray:
     if attributes_present([variable], SYMMETRIC_ATTRIBUTES):
         return value[np.triu_indices(variable.shape[0])]
     elif variable.attributes['diag']:
-        return np.diag(value)
+        return value.diagonal() if sp.issparse(value) else np.diag(value)
     elif variable.attributes['sparsity']:
         if full_size:
             return np.asarray(value)[variable.sparse_idx]
@@ -217,6 +217,8 @@ class CvxAttr2Constr(Reduction):
 
                     reduced_var = Variable(n, var_id=var.id, **new_attr)
                     reduced_var.set_leaf_of_provenance(var)
+                    if var.value is not None:
+                        reduced_var.value = lower_value(var)
                     id2new_var[var.id] = reduced_var
                     obj = build_dim_reduced_expression(var, reduced_var)
                 elif new_var:


### PR DESCRIPTION
When CvxAttr2Constr creates reduced variables for dimension-reducing attributes (e.g. diag=True), the initial value was not propagated to the reduced variable, causing NLP solvers to fail. This mirrors the existing value propagation already done for parameters.

Also handle sparse diagonal matrices in lower_value() by using .diagonal() instead of np.diag() which doesn't accept sparse input.

## Description
Please include a short summary of the change.
Issue link (if applicable):

## Type of change
- [ ] New feature (backwards compatible)
- [ ] New feature (breaking API changes)
- [ ] Bug fix
- [ ] Other (Documentation, CI, ...)

## [Contribution checklist](https://www.cvxpy.org/contributing/index.html#contribution-checklist)
- [ ] Add our license to new files.
- [ ] Check that your code adheres to our coding style.
- [ ] Write unittests.
- [ ] Run the unittests and check that they’re passing.
- [ ] Run the benchmarks to make sure your change doesn’t introduce a regression.