### PR TITLE
[ready for review] add none check

### DIFF
--- a/cvxpy/reductions/solvers/nlp_solving_chain.py
+++ b/cvxpy/reductions/solvers/nlp_solving_chain.py
@@ -209,7 +209,7 @@ def solve_nlp(problem, solver, warm_start, verbose, **kwargs):
         obj_value = problem.objective.value
 
         all_objs[run] = obj_value
-        if obj_value < best_obj:
+        if obj_value is not None and obj_value < best_obj:
             best_obj = obj_value
             best_solution = solution
 


### PR DESCRIPTION
While playing around with best of for a quite nasty problem, Ipopt sometimes failed to converge to a feasible point in one out of 100 times, say. We then compared a None to a float, which led to a crash with TypeError: "'<" not supported between instances of "NoneType" and "float".

I tried to find a minimal test, but the problem I'm working on is very non-self contained so I failed to find add a reasonable test. This check fixes the problem locally though.